### PR TITLE
fix: fail first on error from async-props

### DIFF
--- a/src/server/handle-dynamic.js
+++ b/src/server/handle-dynamic.js
@@ -47,6 +47,12 @@ export default ({ server, config, assets }) => {
 
         // get all the props yo
         loadPropsOnServer(renderProps, loadContext, (err, asyncProps) => {
+          // 500 if error from AsyncProps
+          if (err) {
+            error(err)
+            return reply(err).code(500)
+          }
+          
           let status = 200
 
           const failApi = has(asyncProps.propsArray[0], 'data.data.status')
@@ -54,12 +60,6 @@ export default ({ server, config, assets }) => {
 
           if (failApi || failRoute)
             status = 404
-
-          // 500 if error from AsyncProps
-          if (err) {
-            error(err)
-            return reply(err).code(500)
-          }
 
           // Find HTML based on path - might be undefined
           const cachedHTML = cache.get(request.url.path)


### PR DESCRIPTION
If we don't immediately fail when receiving an error from `async-props`, we'll get an `Unhandled Promise rejection` warning (and an hanging server) when trying to access `asyncProps.propsArray[0]`, since `asyncProps` would most likely be `undefined`.

Pulling the error handler to be executed as soon as we get our callback called from `async-props` will allow us to pass the error back to the user's client.

#### What have you done
…

#### Why have you done it
…

#### Testing carried out to prevent breaking changes
…

_Attach screenshot if visual_
